### PR TITLE
Revamp static visitor logger interface

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,246 @@
+const STORAGE_KEY = 'visitor-insights:entries';
+const MAX_LOG_ENTRIES = 200;
+
+const selectors = {
+  ip: document.querySelector('[data-current-ip]'),
+  location: document.querySelector('[data-current-location]'),
+  organization: document.querySelector('[data-current-organization]'),
+  device: document.querySelector('[data-current-device]'),
+  platform: document.querySelector('[data-current-platform]'),
+  language: document.querySelector('[data-current-language]'),
+  timezone: document.querySelector('[data-current-timezone]'),
+  screen: document.querySelector('[data-current-screen]'),
+  referrer: document.querySelector('[data-current-referrer]'),
+  userAgent: document.querySelector('[data-current-useragent]'),
+  emptyMessage: document.getElementById('emptyMessage'),
+  tableBody: document.getElementById('logTableBody'),
+  downloadButton: document.getElementById('downloadLogs'),
+  clearButton: document.getElementById('clearLogs'),
+};
+
+function detectDeviceType(ua) {
+  const agent = ua.toLowerCase();
+  if (/tablet|ipad|playbook|silk|kindle/.test(agent)) return 'Tablet';
+  if (/mobile|iphone|ipod|android|blackberry|iemobile|opera mini/.test(agent)) return 'Mobile';
+  return 'Desktop';
+}
+
+function getStoredEntries() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored visitor data:', error);
+    return [];
+  }
+}
+
+function persistEntries(entries) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries.slice(0, MAX_LOG_ENTRIES)));
+  } catch (error) {
+    console.warn('Unable to persist visitor data:', error);
+  }
+}
+
+function formatLocation(entry) {
+  const parts = [entry.city, entry.region, entry.country].filter(Boolean);
+  return parts.length ? parts.join(', ') : 'Unavailable';
+}
+
+function updateActionStates(entries) {
+  const hasEntries = entries.length > 0;
+  if (selectors.downloadButton) {
+    selectors.downloadButton.disabled = !hasEntries;
+    selectors.downloadButton.setAttribute('aria-disabled', String(!hasEntries));
+  }
+  if (selectors.clearButton) {
+    selectors.clearButton.disabled = !hasEntries;
+    selectors.clearButton.setAttribute('aria-disabled', String(!hasEntries));
+  }
+}
+
+function updateCurrentVisit(entry) {
+  selectors.ip.textContent = entry.ip || 'Unavailable';
+  selectors.location.textContent = formatLocation(entry);
+  selectors.organization.textContent = entry.organization || 'Unavailable';
+  selectors.device.textContent = `${entry.deviceType}${entry.screenOrientation ? ` (${entry.screenOrientation})` : ''}`;
+  selectors.platform.textContent = entry.platform || 'Unavailable';
+  selectors.language.textContent = entry.language || 'Unavailable';
+  selectors.timezone.textContent = entry.timezone || 'Unavailable';
+  selectors.screen.textContent = entry.screen || 'Unavailable';
+  selectors.referrer.textContent = entry.referrer || 'Direct';
+  selectors.userAgent.textContent = entry.userAgent || 'Unavailable';
+}
+
+function renderLogEntries(entries) {
+  const hasEntries = entries.length > 0;
+  selectors.emptyMessage.hidden = hasEntries;
+  selectors.tableBody.innerHTML = '';
+
+  if (!hasEntries) {
+    updateActionStates(entries);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  entries.forEach((entry) => {
+    const row = document.createElement('tr');
+
+    const cells = [
+      new Date(entry.timestamp).toLocaleString(),
+      entry.ip || 'Unavailable',
+      formatLocation(entry),
+      `${entry.deviceType}${entry.platform ? ` · ${entry.platform}` : ''}`,
+      entry.referrer || 'Direct',
+    ];
+
+    cells.forEach((value) => {
+      const cell = document.createElement('td');
+      cell.textContent = value;
+      row.appendChild(cell);
+    });
+
+    fragment.appendChild(row);
+  });
+
+  selectors.tableBody.appendChild(fragment);
+  updateActionStates(entries);
+}
+
+async function resolveGeolocation() {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const response = await fetch('https://ipapi.co/json/', {
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    return {
+      ip: data.ip,
+      city: data.city,
+      region: data.region,
+      country: data.country_name,
+      latitude: data.latitude,
+      longitude: data.longitude,
+      postal: data.postal,
+      organization: data.org,
+    };
+  } catch (error) {
+    console.warn('Unable to fetch geolocation details:', error);
+    return {};
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function buildBaseEntry() {
+  const ua = navigator.userAgent || 'Unavailable';
+  return {
+    timestamp: new Date().toISOString(),
+    userAgent: ua,
+    deviceType: detectDeviceType(ua),
+    platform: navigator.userAgentData?.platform || navigator.platform || 'Unavailable',
+    language: navigator.language || (navigator.languages && navigator.languages[0]) || 'Unavailable',
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'Unavailable',
+    screen: `${window.screen.width}×${window.screen.height}`,
+    screenOrientation:
+      window.screen.orientation?.type || window.screen.mozOrientation || window.screen.msOrientation || '',
+    referrer: document.referrer || 'Direct',
+    page: window.location.href,
+  };
+}
+
+function downloadCsv(entries) {
+  if (!entries.length) {
+    return;
+  }
+
+  const headers = [
+    'timestamp',
+    'ip',
+    'city',
+    'region',
+    'country',
+    'latitude',
+    'longitude',
+    'postal',
+    'organization',
+    'deviceType',
+    'platform',
+    'language',
+    'timezone',
+    'screen',
+    'screenOrientation',
+    'referrer',
+    'page',
+    'userAgent',
+  ];
+
+  const escape = (value) => {
+    if (value === undefined || value === null) return '';
+    const stringValue = String(value).replace(/"/g, '""');
+    if (/[",\n]/.test(stringValue)) {
+      return `"${stringValue}"`;
+    }
+    return stringValue;
+  };
+
+  const lines = [headers.join(',')];
+
+  entries.forEach((entry) => {
+    const row = headers.map((key) => escape(entry[key]));
+    lines.push(row.join(','));
+  });
+
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'visitor-log.csv';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function clearLog() {
+  localStorage.removeItem(STORAGE_KEY);
+  renderLogEntries([]);
+}
+
+async function init() {
+  const existingEntries = getStoredEntries();
+  renderLogEntries(existingEntries);
+
+  const entry = { ...buildBaseEntry(), ...(await resolveGeolocation()) };
+  updateCurrentVisit(entry);
+
+  const updatedEntries = [entry, ...existingEntries].slice(0, MAX_LOG_ENTRIES);
+  persistEntries(updatedEntries);
+  renderLogEntries(updatedEntries);
+
+  selectors.downloadButton?.addEventListener('click', () => {
+    downloadCsv(getStoredEntries());
+  });
+
+  selectors.clearButton?.addEventListener('click', () => {
+    clearLog();
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/public/index.html
+++ b/public/index.html
@@ -2,14 +2,120 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Visitor Logger</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="A fully client-side visitor logger that records each visit locally and surfaces the captured details instantly."
+    />
+    <title>Visitor Insights Dashboard</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <main>
-      <h1>Welcome</h1>
-      <p>Your visit has been recorded.</p>
+    <main class="page" aria-live="polite">
+      <header class="page__header">
+        <h1>Visitor Insights Dashboard</h1>
+        <p class="lead">
+          This page automatically captures visit information and stores it inside
+          your browser for quick review—no extra confirmation needed.
+        </p>
+      </header>
+
+      <section class="panel" aria-label="Current visit details">
+        <h2>Current Visit</h2>
+        <p class="panel__subtitle">The information shown below updates as soon as we finish gathering it.</p>
+        <dl class="detail-grid">
+          <div>
+            <dt>IP Address</dt>
+            <dd data-current-ip>Fetching&hellip;</dd>
+          </div>
+          <div>
+            <dt>Approximate Location</dt>
+            <dd data-current-location>Fetching&hellip;</dd>
+          </div>
+          <div>
+            <dt>Network / Provider</dt>
+            <dd data-current-organization>Fetching&hellip;</dd>
+          </div>
+          <div>
+            <dt>Device Type</dt>
+            <dd data-current-device>Detecting&hellip;</dd>
+          </div>
+          <div>
+            <dt>Platform</dt>
+            <dd data-current-platform>Detecting&hellip;</dd>
+          </div>
+          <div>
+            <dt>Browser Language</dt>
+            <dd data-current-language>Detecting&hellip;</dd>
+          </div>
+          <div>
+            <dt>Time Zone</dt>
+            <dd data-current-timezone>Detecting&hellip;</dd>
+          </div>
+          <div>
+            <dt>Screen Resolution</dt>
+            <dd data-current-screen>Detecting&hellip;</dd>
+          </div>
+          <div>
+            <dt>Referrer</dt>
+            <dd data-current-referrer>Detecting&hellip;</dd>
+          </div>
+          <div class="detail-grid__full">
+            <dt>User Agent</dt>
+            <dd data-current-useragent>Detecting&hellip;</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="panel" aria-label="Stored visit log">
+        <div class="panel__header">
+          <h2>Saved Visit Log</h2>
+          <div class="panel__actions">
+            <button type="button" id="downloadLogs" class="button" aria-live="off">
+              Download CSV
+            </button>
+            <button type="button" id="clearLogs" class="button button--secondary" aria-live="off">
+              Clear Saved Data
+            </button>
+          </div>
+        </div>
+        <p class="panel__subtitle">
+          A copy of each visit is kept in this browser's local storage so the log stays private and portable.
+        </p>
+        <p id="emptyMessage" class="empty-state">No saved visits yet. Reload the page to capture your first entry.</p>
+        <div class="table-wrapper" role="region" aria-live="polite" aria-atomic="true">
+          <table class="log-table">
+            <caption class="visually-hidden">Historical visit data stored in the browser</caption>
+            <thead>
+              <tr>
+                <th scope="col">Time</th>
+                <th scope="col">IP</th>
+                <th scope="col">Location</th>
+                <th scope="col">Device</th>
+                <th scope="col">Source</th>
+              </tr>
+            </thead>
+            <tbody id="logTableBody"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel" aria-label="How it works">
+        <h2>How This Logger Works</h2>
+        <p>
+          Everything you see here is generated on the client. The page contacts a public geolocation service to resolve
+          your IP address, then saves a summary of the visit to <code>localStorage</code>. Because the data never leaves
+          your browser, you can review it, download it as a CSV file, or clear it whenever you like.
+        </p>
+      </section>
     </main>
+
+    <noscript>
+      <p class="noscript-warning">
+        This experience requires JavaScript to gather and store visit information. Please enable JavaScript and reload the page.
+      </p>
+    </noscript>
+
+    <script src="app.js" defer></script>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,32 +1,247 @@
 :root {
   color-scheme: light dark;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #0f172a;
+  --bg-panel: rgba(15, 23, 42, 0.75);
+  --bg-panel-light: rgba(255, 255, 255, 0.85);
+  --border: rgba(148, 163, 184, 0.35);
+  --accent: #38bdf8;
+  --accent-strong: #0284c7;
+  --text: #f8fafc;
+  --text-muted: rgba(226, 232, 240, 0.75);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  line-height: 1.6;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 35%, #cbd5f5 100%);
+    --bg-panel: rgba(255, 255, 255, 0.9);
+    --bg-panel-light: rgba(255, 255, 255, 0.9);
+    --border: rgba(148, 163, 184, 0.35);
+    --accent: #0369a1;
+    --accent-strong: #0f172a;
+    --text: #0f172a;
+    --text-muted: #475569;
+  }
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
+  background: var(--bg);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  background: radial-gradient(circle at top, #f8fafc, #e2e8f0);
+  padding: clamp(1.5rem, 3vw, 3rem);
+  color: var(--text);
 }
 
-main {
+.page {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 2.5vw, 2.5rem);
+}
+
+.page__header {
   text-align: center;
-  padding: 2rem 3rem;
-  border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
 }
 
 h1 {
-  margin-bottom: 0.5rem;
-  font-size: 2.5rem;
+  margin: 0;
+  font-size: clamp(2.25rem, 5vw, 3rem);
+  letter-spacing: -0.01em;
 }
 
-p {
+.lead {
+  margin-top: 0.5rem;
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  color: var(--text-muted);
+}
+
+.panel {
+  background: var(--bg-panel);
+  backdrop-filter: blur(12px);
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  padding: clamp(1.5rem, 2vw, 2rem);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+}
+
+.panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.panel__subtitle {
+  margin: 0.75rem 0 1.25rem;
+  color: var(--text-muted);
+}
+
+.panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #f8fafc;
+  font-weight: 600;
+  padding: 0.6rem 1.2rem;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  font-size: 0.95rem;
+}
+
+.button:hover,
+.button:focus-visible {
+  background: var(--accent-strong);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(2, 132, 199, 0.35);
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(56, 189, 248, 0.5);
+  outline-offset: 2px;
+}
+
+.button--secondary {
+  background: transparent;
+  color: var(--text);
+  border-color: var(--border);
+  box-shadow: none;
+}
+
+.button--secondary:hover,
+.button--secondary:focus-visible {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text);
+  box-shadow: none;
+}
+
+.detail-grid {
   margin: 0;
-  font-size: 1.1rem;
-  color: #334155;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem 1.5rem;
+}
+
+.detail-grid > div {
+  background: var(--bg-panel-light);
+  padding: 1rem 1.15rem;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: inherit;
+}
+
+.detail-grid__full {
+  grid-column: 1 / -1;
+}
+
+dt {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+dd {
+  margin: 0;
+  font-size: 1rem;
+  word-break: break-word;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--bg-panel-light);
+}
+
+.log-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.log-table th,
+.log-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.log-table tbody tr:hover {
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.log-table th {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.log-table td {
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.empty-state {
+  margin: 0 0 1rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.noscript-warning {
+  margin: 2rem auto;
+  max-width: 640px;
+  background: #fee2e2;
+  color: #991b1b;
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+  border: 1px solid rgba(185, 28, 28, 0.35);
+  text-align: center;
+}
+
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
+
+  .panel {
+    padding: 1.25rem;
+  }
+
+  .table-wrapper {
+    margin: 0 -0.5rem;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the barebones landing page with a visitor insights dashboard that surfaces current session details and explains client-side logging
- add a browser-only logging script that stores visits in localStorage, renders a history table, and offers CSV export/clear controls
- refresh the styling with a responsive glassmorphism-inspired layout that works well when deployed to GitHub Pages

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d6590a70d0832d81382236b734f495